### PR TITLE
Adding Doorkeeper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'pg'
 
 gem 'devise'
 gem 'doorkeeper'
+gem 'active_model_serializers'
 
 group :development do
   gem 'spring'

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,13 @@ gem 'rails-api', github: 'rails-api/rails-api'
 gem 'pg'
 
 gem 'devise'
+gem 'doorkeeper'
 
 group :development do
   gem 'spring'
   gem 'pry-debugger'
+end
+
+group :test do
+  gem 'mocha', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
       activesupport (= 4.1.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)
+    active_model_serializers (0.8.1)
+      activemodel (>= 3.0)
     activemodel (4.1.0)
       activesupport (= 4.1.0)
       builder (~> 3.1)
@@ -123,6 +125,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   devise
   doorkeeper
   mocha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
       railties (>= 3.2.6, < 5)
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    doorkeeper (1.1.0)
+      railties (>= 3.1)
     erubis (2.7.0)
     hike (1.2.3)
     i18n (0.6.9)
@@ -59,9 +61,12 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (1.25.1)
     minitest (5.3.3)
+    mocha (1.0.0)
+      metaclass (~> 0.0.1)
     multi_json (1.9.2)
     orm_adapter (0.5.0)
     pg (0.17.1)
@@ -119,6 +124,8 @@ PLATFORMS
 
 DEPENDENCIES
   devise
+  doorkeeper
+  mocha
   pg
   pry-debugger
   rails (= 4.1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,11 @@ class ApplicationController < ActionController::API
   include ActionController::StrongParameters
 
   respond_to :json
+  doorkeeper_for :all
+
+  protected
+
+  def current_resource_owner
+    User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+  end
 end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -1,0 +1,8 @@
+module V1
+  class UsersController < ApplicationController
+
+    def show
+      respond_with(current_resource_owner)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,11 @@
 class User < ActiveRecord::Base
   before_save :ensure_auth_token
 
-  # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :applications, class_name: 'Doorkeeper::Application', as: :owner
 
   def reset_auth_token
     update_column(:auth_token, generate_auth_token)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :email, :created_at, :updated_at
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,72 @@
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use.
+  # Currently supported options are :active_record, :mongoid2, :mongoid3, :mongo_mapper
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    current_user || warden.authenticate!(scope: :user)
+  end
+
+  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
+  # admin_authenticator do
+  #   # Put your admin authentication logic here.
+  #   # Example implementation:
+  #   Admin.find_by_id(session[:admin_id]) || redirect_to(new_admin_session_url)
+  # end
+
+  # Authorization Code expiration time (default 10 minutes).
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default 2 hours).
+  # If you want to disable expiration, set this to nil.
+  # access_token_expires_in 2.hours
+
+  # Issue access tokens with refresh token (disabled by default)
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
+  # a registered application
+  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
+  enable_application_owner :confirmation => false
+
+  # Define access token scopes for your provider
+  # For more information go to https://github.com/applicake/doorkeeper/wiki/Using-Scopes
+  # default_scopes  :public
+  # optional_scopes :write, :update
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Change the test redirect uri for client apps
+  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
+  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
+  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+  #
+  # test_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with trusted a application.
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # WWW-Authenticate Realm (default "Doorkeeper").
+  # realm "Doorkeeper"
+
+  # Allow dynamic query parameters (disabled by default)
+  # Some applications require dynamic query parameters on their request_uri
+  # set to true if you want this to be allowed
+  # wildcard_redirect_uri false
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,74 @@
+en:
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  mongoid:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  mongo_mapper:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  doorkeeper:
+    errors:
+      messages:
+        # Common error messages
+        invalid_request: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+        invalid_redirect_uri: 'The redirect uri included is not valid.'
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        #configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfiged.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        # Password Access token errors
+        invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
     skip_controllers :applications, :authorized_applications
   end
 
-  scope module: :v1, constrains: ApiConstraints.new('1') do
+  scope module: :v1, defaults: { format: :json }, constrains: ApiConstraints.new('1') do
     devise_for :users, DEVISE_OPTIONS.merge(module: 'v1')
+    get '/user', to: 'users#show'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
     }
   }
 
+  use_doorkeeper do
+    skip_controllers :applications, :authorized_applications
+  end
+
   scope module: :v1, constrains: ApiConstraints.new('1') do
     devise_for :users, DEVISE_OPTIONS.merge(module: 'v1')
   end

--- a/db/migrate/20140425140917_create_doorkeeper_tables.rb
+++ b/db/migrate/20140425140917_create_doorkeeper_tables.rb
@@ -1,0 +1,42 @@
+class CreateDoorkeeperTables < ActiveRecord::Migration
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,         :null => false
+      t.string  :uid,          :null => false
+      t.string  :secret,       :null => false
+      t.text    :redirect_uri, :null => false
+      t.timestamps
+    end
+
+    add_index :oauth_applications, :uid, :unique => true
+
+    create_table :oauth_access_grants do |t|
+      t.integer  :resource_owner_id, :null => false
+      t.integer  :application_id,    :null => false
+      t.string   :token,             :null => false
+      t.integer  :expires_in,        :null => false
+      t.text     :redirect_uri,      :null => false
+      t.datetime :created_at,        :null => false
+      t.datetime :revoked_at
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_grants, :token, :unique => true
+
+    create_table :oauth_access_tokens do |t|
+      t.integer  :resource_owner_id
+      t.integer  :application_id
+      t.string   :token,             :null => false
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.datetime :revoked_at
+      t.datetime :created_at,        :null => false
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_tokens, :token, :unique => true
+    add_index :oauth_access_tokens, :resource_owner_id
+    add_index :oauth_access_tokens, :refresh_token, :unique => true
+
+  end
+end

--- a/db/migrate/20140425142530_add_owner_to_application.rb
+++ b/db/migrate/20140425142530_add_owner_to_application.rb
@@ -1,0 +1,7 @@
+class AddOwnerToApplication < ActiveRecord::Migration
+  def change
+    add_column :oauth_applications, :owner_id, :integer, :null => true
+    add_column :oauth_applications, :owner_type, :string, :null => true
+    add_index :oauth_applications, [:owner_id, :owner_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140425044331) do
+ActiveRecord::Schema.define(version: 20140425142530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "oauth_access_grants", force: true do |t|
+    t.integer  "resource_owner_id", null: false
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.integer  "expires_in",        null: false
+    t.text     "redirect_uri",      null: false
+    t.datetime "created_at",        null: false
+    t.datetime "revoked_at"
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+
+  create_table "oauth_access_tokens", force: true do |t|
+    t.integer  "resource_owner_id"
+    t.integer  "application_id"
+    t.string   "token",             null: false
+    t.string   "refresh_token"
+    t.integer  "expires_in"
+    t.datetime "revoked_at"
+    t.datetime "created_at",        null: false
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+
+  create_table "oauth_applications", force: true do |t|
+    t.string   "name",         null: false
+    t.string   "uid",          null: false
+    t.string   "secret",       null: false
+    t.text     "redirect_uri", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "owner_id"
+    t.string   "owner_type"
+  end
+
+  add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
 
   create_table "users", force: true do |t|
     t.string   "email",                  default: "", null: false

--- a/test/integration/v1/login_test.rb
+++ b/test/integration/v1/login_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class V1::LoginTest < ActionDispatch::IntegrationTest
   api_version 1
 
+  setup do
+    authenticate_as(:david)
+  end
+
   test 'succeeds and regenerates token with valid credentials' do
     user = users(:david)
 

--- a/test/integration/v1/user_api_test.rb
+++ b/test/integration/v1/user_api_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class V1::UserAPITest < ActionDispatch::IntegrationTest
+  api_version 1
+
+  test '/user returns the currently logged in user' do
+    authenticate_as(:david)
+
+    get '/user'
+    assert_response :success
+    refute response.body.include?('"auth_token":')
+  end
+end

--- a/test/support/api_test.rb
+++ b/test/support/api_test.rb
@@ -15,8 +15,15 @@ module APITest
   module APITestHelpers
 
     def post(uri, params = {}, headers = {})
-      default_headers = { 'HTTP_ACCEPT' => 'vnd.pseudocms.v%s+json' % api_version }
       super(uri, params, default_headers.merge(headers))
+    end
+
+    def get(uri, params = {}, headers = {})
+      super(uri, params, default_headers.merge(headers))
+    end
+
+    def default_headers
+      { 'HTTP_ACCEPT' => 'vnd.pseudocms.v%s-json' % api_version }
     end
 
     def authenticate_as(fixture_name)

--- a/test/support/api_test.rb
+++ b/test/support/api_test.rb
@@ -19,6 +19,17 @@ module APITest
       super(uri, params, default_headers.merge(headers))
     end
 
+    def authenticate_as(fixture_name)
+      user = users(fixture_name)
+      app = user.applications.create(name: 'APITest', redirect_uri: 'http://test.com')
+      token = Doorkeeper::AccessToken.create!(
+        application_id: app.id,
+        resource_owner_id: user.id
+      )
+
+      ApplicationController.any_instance.stubs(:doorkeeper_token).returns(token)
+    end
+
     def encode_credentials(user, pass)
       ActionController::HttpAuthentication::Basic.encode_credentials(user, pass)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/pride'
+require 'mocha/setup'
 require 'pry'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
Adding doorkeeper and related configuration to support oauth.

From any of the controllers, you can access the current user (based on the token), but using `current_resource_owner`. This will return a `User` object for the current user.

When testing, use the `authenticate_as` method to properly stub the token.
