### PR TITLE
Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'doorkeeper'
 gem 'active_model_serializers'
 
 gem 'figaro'
-gem 'will_paginate'
+gem 'will_paginate', github: 'pseudomuto/will_paginate', ref: 'first_last_page_predicates_for_collection'
 
 group :development do
   gem 'spring'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'doorkeeper'
 gem 'active_model_serializers'
 
 gem 'figaro'
+gem 'will_paginate'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/pseudomuto/will_paginate.git
+  revision: c659902cc93e1dab06bd9595b3ccd22bd6be4cdb
+  ref: first_last_page_predicates_for_collection
+  specs:
+    will_paginate (3.0.4)
+
+GIT
   remote: git://github.com/rails-api/rails-api.git
   revision: 62cbe9fde403822c40fb31d0bd897c608f104d51
   specs:
@@ -139,7 +146,6 @@ GEM
       unicorn
     warden (1.2.3)
       rack (>= 1.0)
-    will_paginate (3.0.5)
 
 PLATFORMS
   ruby
@@ -158,4 +164,4 @@ DEPENDENCIES
   spring
   spring-commands-testunit
   unicorn-rails
-  will_paginate
+  will_paginate!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
       unicorn
     warden (1.2.3)
       rack (>= 1.0)
+    will_paginate (3.0.5)
 
 PLATFORMS
   ruby
@@ -157,3 +158,4 @@ DEPENDENCIES
   spring
   spring-commands-testunit
   unicorn-rails
+  will_paginate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::API
   include ActionController::ImplicitRender
   include ActionController::StrongParameters
   include Authorizable
+  include Paginator
 
   respond_to :json
   doorkeeper_for :all

--- a/app/controllers/concerns/paginator.rb
+++ b/app/controllers/concerns/paginator.rb
@@ -1,0 +1,20 @@
+module Paginator
+  extend ActiveSupport::Concern
+
+  PAGINATOR_DEFAULTS = {
+    page: 1,
+    per_page: WillPaginate.per_page
+  }
+
+  def paginate(resource)
+    page_params = paginator_params
+    page_params[:page] = [page_params[:page], 1].max
+    resource.paginate(page_params)
+  end
+
+  private
+
+  def paginator_params
+    PAGINATOR_DEFAULTS.merge(params.permit(:page, :per_page)).symbolize_keys
+  end
+end

--- a/app/controllers/concerns/paginator.rb
+++ b/app/controllers/concerns/paginator.rb
@@ -1,25 +1,58 @@
 module Paginator
   extend ActiveSupport::Concern
 
+  DEFAULT_MAX_PER_PAGE = 100
+
   PAGINATOR_DEFAULTS = {
     page: 1,
     per_page: WillPaginate.per_page
   }
 
-  def paginate(resource)
+  def paginate(resource, base_uri = '')
     page_params = paginator_params
     page_params[:page] = [page_params[:page], 1].max
     page_params[:per_page] = [page_params[:per_page], max_per_page].min
-    resource.paginate(page_params)
+
+    collection = resource.paginate(page_params)
+    set_link_header(base_uri, collection, page_params[:per_page])
+    collection
   end
 
   def max_per_page
-    100
+    DEFAULT_MAX_PER_PAGE
+  end
+
+  def query_for_page(page, per_page)
+    "?page=#{page}&per_page=#{per_page}"
   end
 
   private
 
   def paginator_params
-    PAGINATOR_DEFAULTS.merge(params.permit(:page, :per_page)).symbolize_keys
+    supplied_params = params.permit(:page, :per_page)
+    page_params = PAGINATOR_DEFAULTS.merge(supplied_params).symbolize_keys
+    Hash[page_params.map { |key, value| [key, Integer(value)] }]
+  end
+
+  def set_link_header(base_uri, collection, per_page)
+    links = paginator_page_links(collection).map do |rel, page_num|
+      "<#{base_uri}#{query_for_page(page_num, per_page)}>; rel=#{rel}"
+    end
+
+    response.headers['Link'] = links.join(',')
+  end
+
+  def paginator_page_links(collection)
+    {}.tap do |pages|
+      unless collection.first_page?
+        pages[:first] = 1
+        pages[:prev] = collection.current_page - 1
+      end
+
+      unless collection.last_page?
+        pages[:last] = collection.total_pages
+        pages[:next] = collection.current_page + 1
+      end
+    end
   end
 end

--- a/app/controllers/concerns/paginator.rb
+++ b/app/controllers/concerns/paginator.rb
@@ -9,7 +9,12 @@ module Paginator
   def paginate(resource)
     page_params = paginator_params
     page_params[:page] = [page_params[:page], 1].max
+    page_params[:per_page] = [page_params[:per_page], max_per_page].min
     resource.paginate(page_params)
+  end
+
+  def max_per_page
+    100
   end
 
   private

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -8,7 +8,8 @@ module V1
 
     # GET /users
     def index
-      respond_with(paginate(User.all))
+      users = paginate(User.all, users_url)
+      respond_with(users)
     end
 
     # GET /user

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -4,10 +4,11 @@ module V1
     allow(:user)   { current_user }
     allow(:show)   { blessed_app? || account_owner? }
     allow(:update) { account_owner? || blessed_app? }
+    deny(:create)  { current_user || !blessed_app? }
 
     # GET /users
     def index
-      respond_with(User.all)
+      respond_with(paginate(User.all))
     end
 
     # GET /user
@@ -23,8 +24,6 @@ module V1
 
     # POST /users
     def create
-      return head(403) if current_user || !blessed_app?
-
       user = User.create(user_params)
       respond_with(user, location: user)
     end

--- a/test/controllers/concerns/paginator_test.rb
+++ b/test/controllers/concerns/paginator_test.rb
@@ -3,50 +3,66 @@ require 'test_helper'
 class PaginatorTest < ActiveSupport::TestCase
   class SampleController < ActionController::API
     include Paginator
+
+    def response
+      @response ||= ActionDispatch::Response.new
+    end
+
+    def url_for_page(page, per_page)
+      ''
+    end
   end
 
   test '#paginate calls paginate on supplied resource' do
     resource = mock()
-    resource.expects(:paginate)
+    resource.expects(:paginate).returns(collection_stub)
     controller.paginate(resource)
   end
 
   test '#paginate uses supplied params when present' do
     resource = mock()
-    resource.expects(:paginate).with(has_entries(page: 3, per_page: 10))
+    expect_paginate resource, with: has_entries(page: 3, per_page: 10)
     controller(page: 3, per_page: 10).paginate(resource)
   end
 
   test 'page parameter defaults to 1' do
     resource = mock()
-    resource.expects(:paginate).with(has_entries(page: 1))
+    expect_paginate resource, with: has_entries(page: 1)
     controller.paginate(resource)
   end
 
   test 'page parameter cannot be less than 1' do
     resource = mock()
-    resource.expects(:paginate).with(has_entries(page: 1))
+    expect_paginate resource, with: has_entries(page: 1)
     controller(page: 0).paginate(resource)
   end
 
   test 'per_page parameter defaults to WillPaginate.per_page' do
     resource = mock()
-    resource.expects(:paginate).with(has_entries(per_page: WillPaginate.per_page))
+    expect_paginate resource, with: has_entries(per_page: WillPaginate.per_page)
     controller.paginate(resource)
   end
 
   test 'per_page parameter tops out at #max_per_page' do
     expected_page_size = SampleController.new.max_per_page
     resource = mock()
-    resource.expects(:paginate).with(has_entries(per_page: expected_page_size))
+    expect_paginate resource, with: has_entries(per_page: expected_page_size)
     controller(per_page: expected_page_size + 1).paginate(resource)
   end
 
   private
 
+  def expect_paginate(collection, with: {}, returns: collection_stub)
+    collection.expects(:paginate).with(with).returns(returns)
+  end
+
   def controller(params = {})
     @controller ||= SampleController.new.tap do |klass|
       klass.params = ActionController::Parameters.new(params)
     end
+  end
+
+  def collection_stub(first_page: true, last_page: true)
+    stub(first_page?: first_page, last_page?: last_page)
   end
 end

--- a/test/controllers/concerns/paginator_test.rb
+++ b/test/controllers/concerns/paginator_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class PaginatorTest < ActiveSupport::TestCase
+  class SampleController < ActionController::API
+    include Paginator
+  end
+
+  test '#paginate calls paginate on supplied resource' do
+    resource = mock()
+    resource.expects(:paginate)
+    controller.paginate(resource)
+  end
+
+  test '#paginate uses supplied params when present' do
+    resource = mock()
+    resource.expects(:paginate).with(has_entries(page: 3, per_page: 10))
+    controller(page: 3, per_page: 10).paginate(resource)
+  end
+
+  test 'page parameter defaults to 1' do
+    resource = mock()
+    resource.expects(:paginate).with(has_entries(page: 1))
+    controller.paginate(resource)
+  end
+
+  test 'page parameter cannot be less than 1' do
+    resource = mock()
+    resource.expects(:paginate).with(has_entries(page: 1))
+    controller(page: 0).paginate(resource)
+  end
+
+  test 'per_page parameter defaults to WillPaginate.per_page' do
+    resource = mock()
+    resource.expects(:paginate).with(has_entries(per_page: WillPaginate.per_page))
+    controller.paginate(resource)
+  end
+
+  private
+
+  def controller(params = {})
+    @controller ||= SampleController.new.tap do |klass|
+      klass.params = ActionController::Parameters.new(params)
+    end
+  end
+end

--- a/test/controllers/concerns/paginator_test.rb
+++ b/test/controllers/concerns/paginator_test.rb
@@ -35,6 +35,13 @@ class PaginatorTest < ActiveSupport::TestCase
     controller.paginate(resource)
   end
 
+  test 'per_page parameter tops out at #max_per_page' do
+    expected_page_size = SampleController.new.max_per_page
+    resource = mock()
+    resource.expects(:paginate).with(has_entries(per_page: expected_page_size))
+    controller(per_page: expected_page_size + 1).paginate(resource)
+  end
+
   private
 
   def controller(params = {})

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -5,3 +5,9 @@ david:
 xavier:
   email: x@pseudocms.com
   encrypted_password: <%= User.new.send(:password_digest, 'BatmanFTW!') %>
+
+<% 1.upto(30) do |i| %>
+user_<%= i %>:
+  email: user_<%= i %>@pseudocms.com
+  encrypted_password: <%= User.new.send(:password_digest, 'pAssword1') %>
+<% end %>

--- a/test/integration/v1/users_api_test.rb
+++ b/test/integration/v1/users_api_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class V1::UserAPITest < ActionDispatch::IntegrationTest
   api_version 1
+  pagination_test :paged_users_request
 
   test 'getting all users requires client credentials' do
     user_auth(:david)
@@ -24,6 +25,14 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_kind_of Array, response_hash['users']
     assert response_hash['users'].size > 0
+  end
+
+  test 'getting all users sets the link header' do
+    client_auth(:blessed_app)
+
+    get '/users'
+    assert_response :ok
+    assert response.headers.has_key?('Link')
   end
 
   test 'GET /user returns the currently logged in user' do
@@ -158,5 +167,10 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
 
   def user_params(email: 'test@pseudocms.com', password: 'pAssword1')
     { user: { email: email, password: password } }
+  end
+
+  def paged_users_request(page, per_page)
+    client_auth(:blessed_app)
+    get '/users', page: page, per_page: per_page
   end
 end

--- a/test/support/api_test.rb
+++ b/test/support/api_test.rb
@@ -10,6 +10,73 @@ module APITest
 
       send(:include, APITestHelpers)
     end
+
+    def pagination_test(setup_method)
+      define_method :pagination_setup do |page, per_page|
+        send(setup_method, page, per_page)
+      end
+
+      send(:include, PagingTestHelpers)
+    end
+  end
+
+  module PagingTestHelpers
+    def test_pagination_for_first_page
+      pagination_setup(1, 1)
+      assert_response :ok
+
+      refute page_links.has_key?(:first)
+      refute page_links.has_key?(:prev)
+      assert page_links.has_key?(:next)
+      assert page_links.has_key?(:last)
+    end
+
+    def test_pagination_for_middle_page
+      pagination_setup(2, 1)
+      assert_response :ok
+
+      assert page_links.has_key?(:first)
+      assert page_links.has_key?(:prev)
+      assert page_links.has_key?(:next)
+      assert page_links.has_key?(:last)
+    end
+
+    def test_pagination_for_last_page
+      last_page = last_page_number
+      pagination_setup(last_page, 1)
+      assert_response :ok
+
+      assert page_links.has_key?(:first)
+      assert page_links.has_key?(:prev)
+      refute page_links.has_key?(:next)
+      refute page_links.has_key?(:last)
+    end
+
+    private
+
+    LINK_HEADER_PATTERN = /\A<([^>]+)>;\s*rel=(.*)\z/
+
+    def page_links
+      @page_links ||= begin
+        headers = response.headers['Link'].split(',').map(&:strip)
+        {}.tap do |links|
+          headers.each do |header|
+            if LINK_HEADER_PATTERN =~ header
+              links[$2] = $1
+            end
+          end
+
+          links.symbolize_keys!
+        end
+      end
+    end
+
+    def last_page_number
+      pagination_setup(1, 1)
+      last_page = page_links[:last][/page=(\d+)/][$1]
+      @page_links = nil
+      last_page
+    end
   end
 
   module APITestHelpers


### PR DESCRIPTION
Adding a [Link](http://tools.ietf.org/html/rfc5988) header to paged responses.
- First page: links for `:next` and `:last`
- Last page: links for `:prev` and `:first`
- Other pages: all the links
