### PR TITLE
Adding the Ability to Delete Users

### DIFF
--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -4,13 +4,13 @@ module Authorizable
   module ClassMethods
     def allow(action, &block)
       before_action only: [action] do
-        head(403) unless instance_eval(&block)
+        head(:forbidden) unless instance_eval(&block)
       end
     end
 
     def deny(action, &block)
       before_action only: [action] do
-        head(403) if instance_eval(&block)
+        head(:forbidden) if instance_eval(&block)
       end
     end
   end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -42,9 +42,9 @@ module V1
     def destroy
       user = User.find(params[:id])
       user.destroy
-      head :no_content
+      head(:no_content)
     rescue ActiveRecord::RecordNotFound
-      head :not_found
+      head(:not_found)
     end
 
     private

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -1,10 +1,11 @@
 module V1
   class UsersController < ApplicationController
-    allow(:index)  { blessed_app? }
-    allow(:user)   { current_user }
-    allow(:show)   { blessed_app? || account_owner? }
-    allow(:update) { account_owner? || blessed_app? }
-    allow(:create) { blessed_app? }
+    allow(:index)   { blessed_app? }
+    allow(:user)    { current_user }
+    allow(:show)    { blessed_app? || account_owner? }
+    allow(:update)  { account_owner? || blessed_app? }
+    allow(:create)  { blessed_app? }
+    allow(:destroy) { blessed_app? }
 
     # GET /users
     def index
@@ -35,6 +36,15 @@ module V1
       user = User.find(params[:id])
       user.update_attributes(user_params)
       respond_with(user)
+    end
+
+    # DELETE /users/:id
+    def destroy
+      user = User.find(params[:id])
+      user.destroy
+      head :no_content
+    rescue ActiveRecord::RecordNotFound
+      head :not_found
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
   scope module: :v1, defaults: { format: :json }, constraints: ApiConstraints.new('1', default: true) do
     devise_for :users, devise_options.merge(module: 'v1')
     get '/user', to: 'users#user'
-    resources :users, except: [:new, :edit, :destroy]
+    resources :users, except: [:new, :edit]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
   end
 
   scope module: :v1, defaults: { format: :json }, constraints: ApiConstraints.new('1', default: true) do
-    devise_for :users, devise_options.merge(module: 'v1')
     get '/user', to: 'users#user'
     resources :users, except: [:new, :edit]
   end

--- a/test/integration/v1/users_api_test.rb
+++ b/test/integration/v1/users_api_test.rb
@@ -8,14 +8,14 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     user_auth(:david)
 
     get '/users'
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'getting all users requires the authenticated client to be blessed' do
     client_auth(:normal_app)
 
     get '/users'
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'getting all users returns users' do
@@ -47,7 +47,7 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     client_auth(:normal_app)
 
     get '/user'
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'the authenticated user can look up themselves' do
@@ -64,7 +64,7 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
 
     user = users(:xavier)
     get "/users/#{user.id}"
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'blessed clients can look up a specific user' do
@@ -81,21 +81,21 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
 
     user = users(:david)
     get "/users/#{user.id}"
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'creating a user requires client authentication' do
     user_auth(:david)
 
     post '/users', user_params
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'creating a user requires a blessed client' do
     client_auth(:normal_app)
 
     post '/users', user_params
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'creating a user succeeds with valid parameters' do
@@ -143,7 +143,7 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
 
     user = users(:xavier)
     patch "/users/#{user.id}", user_params
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'a blessed client can update any user account' do
@@ -160,7 +160,7 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
 
     user = users(:xavier)
     patch "/users/#{user.id}", user_params
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'a blessed client can delete a user account' do

--- a/test/integration/v1/users_api_test.rb
+++ b/test/integration/v1/users_api_test.rb
@@ -163,6 +163,35 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     assert_response 403
   end
 
+  test 'a blessed client can delete a user account' do
+    client_auth(:blessed_app)
+
+    user = users(:xavier)
+    assert_difference 'User.count', -1 do
+      delete "/users/#{user.id}"
+      assert_response :no_content
+    end
+  end
+
+  test 'a 404 is returned when deleting a user that doesn\'t exist' do
+    client_auth(:blessed_app)
+
+    assert_no_difference 'User.count' do
+      delete '/users/0'
+      assert_response :not_found
+    end
+  end
+
+  test 'non-blessed clients can\'t delete a user' do
+    client_auth(:normal_app)
+
+    user = users(:xavier)
+    assert_no_difference 'User.count' do
+      delete "/users/#{user.id}"
+      assert_response :forbidden
+    end
+  end
+
   private
 
   def user_params(email: 'test@pseudocms.com', password: 'pAssword1')

--- a/test/support/api_test.rb
+++ b/test/support/api_test.rb
@@ -93,6 +93,10 @@ module APITest
       super(uri, params, default_headers.merge(headers))
     end
 
+    def delete(uri, params = {}, headers = {})
+      super(uri, params, default_headers.merge(headers))
+    end
+
     private
 
     def default_headers


### PR DESCRIPTION
Blessed applications/clients can now delete users at _/users/:id_.
- If a user is not found, a 404 is returned
- If the caller is not blessed, a 403 is returned
- On successful destroy, a 204 is returned
