### PR TITLE
Sites API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,12 @@ class ApplicationController < ActionController::API
 
   respond_to :json
   doorkeeper_for :all
+
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  protected
+
+  def not_found
+    head(:not_found)
+  end
 end

--- a/app/controllers/v1/sites_controller.rb
+++ b/app/controllers/v1/sites_controller.rb
@@ -1,7 +1,9 @@
 module V1
   class SitesController < ApplicationController
     allow(:index) { blessed_app? || current_user }
+    allow(:create) { blessed_app? || current_user }
 
+    # GET /sites
     def index
       sites = if blessed_app?
                 Site.all
@@ -10,6 +12,37 @@ module V1
               end
 
       respond_with(paginate(sites, sites_url))
+    end
+
+    # GET /sites/:id
+    def show
+      site = Site.find(params[:id])
+      return head(:forbidden) unless blessed_app? || site.users.include?(current_user)
+
+      respond_with(site)
+    end
+
+    # POST /sites
+    def create
+      user = current_user
+      user = User.find(owner_params[:owner_id]) if blessed_app?
+
+      site = user.owned_sites.create(create_params)
+      respond_with(site, location: site)
+    end
+
+    private
+
+    def create_params
+      params.require(:site).permit(:name, :description)
+    end
+
+    def owner_params
+      params.require(:site).permit(:owner_id)
+    end
+
+    def site_not_found
+      head(:not_found)
     end
   end
 end

--- a/app/controllers/v1/sites_controller.rb
+++ b/app/controllers/v1/sites_controller.rb
@@ -1,0 +1,15 @@
+module V1
+  class SitesController < ApplicationController
+    allow(:index) { blessed_app? || current_user }
+
+    def index
+      sites = if blessed_app?
+                Site.all
+              else
+                current_user.sites
+              end
+
+      respond_with(paginate(sites, sites_url))
+    end
+  end
+end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -56,8 +56,6 @@ module V1
     def ensure_no_site_ownership
       user = User.find(params[:id])
       head(:precondition_failed) if user.owned_sites.any?
-    rescue ActiveRecord::RecordNotFound
-      head(:not_found)
     end
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,14 @@
 class Site < ActiveRecord::Base
+  belongs_to :owner, class_name: 'User', foreign_key: 'user_id'
   has_and_belongs_to_many :users
 
+  after_commit :ensure_user_mapping, on: :create
+
   validates :name, presence: true, uniqueness: true
+
+  private
+
+  def ensure_user_mapping
+    users << User.find(owner.id)
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,0 +1,5 @@
+class Site < ActiveRecord::Base
+  has_and_belongs_to_many :users
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,9 @@
 class User < ActiveRecord::Base
-  has_and_belongs_to_many :sites
-
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :applications, class_name: 'Doorkeeper::Application', as: :owner
+  has_and_belongs_to_many :sites
+  has_many :owned_sites, class_name: 'Site'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  has_and_belongs_to_many :sites
+
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -5,10 +5,12 @@ Doorkeeper.configure do
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
+    logger.warn "attempting to auth"
     current_user || warden.authenticate!(scope: :user)
   end
 
   resource_owner_from_credentials do |routes|
+    Rails.logger.warn "attempting to login : #{request.params[:username]}"
     user = User.find_for_database_authentication(email: request.params[:username])
     user if user && user.valid_password?(request.params[:password])
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
   scope module: :v1, defaults: { format: :json }, constraints: ApiConstraints.new('1', default: true) do
     get '/user', to: 'users#user'
     resources :users, except: [:new, :edit]
-    resources :sites, only: [:index]
+    resources :sites, only: [:index, :show, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,6 @@ Rails.application.routes.draw do
   scope module: :v1, defaults: { format: :json }, constraints: ApiConstraints.new('1', default: true) do
     get '/user', to: 'users#user'
     resources :users, except: [:new, :edit]
+    resources :sites, only: [:index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
   scope module: :v1, defaults: { format: :json }, constraints: ApiConstraints.new('1', default: true) do
     get '/user', to: 'users#user'
     resources :users, except: [:new, :edit]
-    resources :sites, except: [:new, :edit, :destroy]
+    resources :sites, except: [:new, :edit]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
   scope module: :v1, defaults: { format: :json }, constraints: ApiConstraints.new('1', default: true) do
     get '/user', to: 'users#user'
     resources :users, except: [:new, :edit]
-    resources :sites, only: [:index, :show, :create]
+    resources :sites, except: [:new, :edit, :destroy]
   end
 end

--- a/db/migrate/20140711234654_create_sites.rb
+++ b/db/migrate/20140711234654_create_sites.rb
@@ -1,0 +1,12 @@
+class CreateSites < ActiveRecord::Migration
+  def change
+    create_table :sites do |t|
+      t.string :name, null: false, length: { max: 200 }
+      t.string :description
+
+      t.timestamps
+    end
+
+    add_index :sites, :name, unique: true
+  end
+end

--- a/db/migrate/20140712233438_sites_users.rb
+++ b/db/migrate/20140712233438_sites_users.rb
@@ -1,0 +1,12 @@
+class SitesUsers < ActiveRecord::Migration
+  def change
+    create_table :sites_users, id: false do |t|
+      t.belongs_to :user
+      t.belongs_to :site
+    end
+
+    add_index :sites_users, [:user_id, :site_id], unique: true
+    add_index :sites_users, :user_id
+    add_index :sites_users, :site_id
+  end
+end

--- a/db/migrate/20140714000056_add_user_to_sites.rb
+++ b/db/migrate/20140714000056_add_user_to_sites.rb
@@ -1,0 +1,5 @@
+class AddUserToSites < ActiveRecord::Migration
+  def change
+    add_column :sites, :user_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140503175917) do
+ActiveRecord::Schema.define(version: 20140712233438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,24 @@ ActiveRecord::Schema.define(version: 20140503175917) do
 
   add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
   add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
+
+  create_table "sites", force: true do |t|
+    t.string   "name",        null: false
+    t.string   "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sites", ["name"], name: "index_sites_on_name", unique: true, using: :btree
+
+  create_table "sites_users", id: false, force: true do |t|
+    t.integer "user_id"
+    t.integer "site_id"
+  end
+
+  add_index "sites_users", ["site_id"], name: "index_sites_users_on_site_id", using: :btree
+  add_index "sites_users", ["user_id", "site_id"], name: "index_sites_users_on_user_id_and_site_id", unique: true, using: :btree
+  add_index "sites_users", ["user_id"], name: "index_sites_users_on_user_id", using: :btree
 
   create_table "users", force: true do |t|
     t.string   "email",                  default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140712233438) do
+ActiveRecord::Schema.define(version: 20140714000056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20140712233438) do
     t.string   "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "user_id",     null: false
   end
 
   add_index "sites", ["name"], name: "index_sites_on_name", unique: true, using: :btree

--- a/test/factories/sites.rb
+++ b/test/factories/sites.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :site do
+    sequence(:name) { |n| "site ##{n}" }
+    description "Site description"
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-    email "user@pseudomuto.com"
+    sequence(:email) { |n| "user-#{n}@pseudocms.com" }
     password "pAssword1"
   end
 end

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -3,3 +3,4 @@
 pseudocms:
   name: PseudoCMS
   description: Some site
+  owner: david

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -1,0 +1,5 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+pseudocms:
+  name: PseudoCMS
+  description: Some site

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -1,6 +1,0 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-pseudocms:
-  name: PseudoCMS
-  description: Some site
-  owner: david

--- a/test/integration/v1/sites_api_test.rb
+++ b/test/integration/v1/sites_api_test.rb
@@ -40,6 +40,121 @@ class V1::SitesAPITest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  test "a user can get a site they own" do
+    user = user_auth(:david)
+    site = make_site(user)
+
+    get "/sites/#{site.id}"
+    assert_response :success
+    assert_equal site.name, json_response["name"]
+  end
+
+  test "a user can get a site they are associated with" do
+    user, other_user = create(:user), user_auth(:david)
+    site = make_site(user)
+    site.users << other_user
+
+    get "/sites/#{site.id}"
+    assert_response :success
+  end
+
+  test "a user can't get a site they are not associated with" do
+    user, other_user = create(:user), user_auth(:david)
+    site = make_site(user)
+
+    get "/sites/#{site.id}"
+    assert_response :forbidden
+  end
+
+  test "a blessed app can get any site" do
+    client_auth(blessed: true)
+
+    user = create(:user)
+    site = make_site(user)
+
+    get "/sites/#{site.id}"
+    assert_response :success
+    assert_equal site.name, json_response["name"]
+  end
+
+  test "when a site is not found, a 404 is returned" do
+    client_auth(blessed: true)
+
+    get "/sites/0"
+    assert_response :not_found
+  end
+
+  test "getting a site requires blessed app or user authentication" do
+    client_auth
+
+    user = create(:user)
+    site = make_site(user)
+
+    get "/sites/#{site.id}"
+    assert_response :forbidden
+  end
+
+  test "users can create sites" do
+    user = user_auth(:david)
+
+    assert_difference ["Site.count", "user.owned_sites.count"] do
+      post "/sites", site_params
+      assert_response :success
+    end
+  end
+
+  test "blessed apps can create sites for any user" do
+    client_auth(blessed: true)
+    user = create(:user)
+
+    assert_difference ["Site.count", "user.owned_sites.count"] do
+      post "/sites", site_params(owner_id: user.id)
+      assert_response :success
+    end
+  end
+
+  test "when creating a site, blessed apps must pass the owner_id" do
+    client_auth(blessed: true)
+
+    assert_no_difference "Site.count" do
+      post "/sites", site_params
+      assert_response :not_found
+    end
+  end
+
+  test "when a user creates a site, the owner_id is ignored" do
+    user = user_auth(:david)
+
+    assert_difference ["Site.count", "user.owned_sites.count"] do
+      post "/sites", site_params(owner_id: -200) #ignored
+      assert_response :success
+    end
+  end
+
+  test "creating a site requires blessed app or user authentication" do
+    client_auth
+
+    assert_no_difference ["Site.count"] do
+      post "/sites", site_params
+      assert_response :forbidden
+    end
+  end
+
+  test "creating a site with invalid params returns unprocessable entity" do
+    user = user_auth(:david)
+
+    assert_no_difference "Site.count" do
+      post "/sites", site_params(name: "")
+      assert_response :unprocessable_entity
+    end
+
+    site = create(:site, owner: user)
+    assert_no_difference "Site.count" do
+      post "/sites", site_params(name: site.name)
+      assert_response :unprocessable_entity
+    end
+  end
+
   private
 
   def paged_sites_request(page, per_page)
@@ -56,5 +171,9 @@ class V1::SitesAPITest < ActionDispatch::IntegrationTest
   def make_site(owner, attrs = {})
     defaults = { owner: owner, users: Array.wrap(owner) }
     create(:site, defaults.merge(attrs))
+  end
+
+  def site_params(attrs = {})
+    { site: { name: "Some Site", description: "Some description" }.merge(attrs) }
   end
 end

--- a/test/integration/v1/sites_api_test.rb
+++ b/test/integration/v1/sites_api_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class V1::SitesAPITest < ActionDispatch::IntegrationTest
+  api_version 1
+  pagination_test :paged_sites_request
+
+  test "getting all sites when logged in as a user returns only their sites" do
+    user = user_auth(:david)
+    other_user = create(:user)
+
+    make_site(user, name: "SiteA")
+    make_site(other_user, name: "SiteB")
+
+    get "/sites"
+    assert_response :success
+    assert_kind_of Array, json_response
+    assert_equal 1, json_response.size
+    refute json_response.map { |site| site["name"] }.include?("SiteB")
+  end
+
+  test "getting all sites as a blessed app returns all sites" do
+    client_auth(blessed: true)
+
+    user, other_user = create(:user), create(:user)
+    make_site(user, name: "SiteA")
+    make_site(other_user, name: "SiteB")
+
+    get "/sites"
+    assert_response :success
+    assert_kind_of Array, json_response
+
+    names = json_response.map { |site| site["name"] }
+    ["SiteA", "SiteB"].each { |name| assert names.include?(name) }
+  end
+
+  test "getting all sites requires blessed_app or user token" do
+    client_auth
+
+    get "/sites"
+    assert_response :forbidden
+  end
+
+  private
+
+  def paged_sites_request(page, per_page)
+    user = user_auth(:david)
+    make_sites(user)
+
+    get "/sites", page: page, per_page: per_page
+  end
+
+  def make_sites(owner, num: 10)
+    [1, num].max.times { make_site(owner) }
+  end
+
+  def make_site(owner, attrs = {})
+    defaults = { owner: owner, users: Array.wrap(owner) }
+    create(:site, defaults.merge(attrs))
+  end
+end

--- a/test/integration/v1/users_api_test.rb
+++ b/test/integration/v1/users_api_test.rb
@@ -182,9 +182,11 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
   end
 
   test "a 412 is returned when deleting a user that is an owner of a site" do
-    client_auth(:blessed_app)
+    client_auth(blessed: true)
 
-    user = users(:david)
+    user = create(:user)
+    site = create(:site, owner: user)
+
     assert_no_difference "User.count" do
       delete "/users/#{user.id}"
       assert_response :precondition_failed
@@ -215,6 +217,6 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
   end
 
   def make_users(num: 10)
-    1.upto([1, num].max) { |n| create(:user, email: "user-#{n}@pseudocms.com") }
+    [1, num].max.times { create(:user) }
   end
 end

--- a/test/integration/v1/users_api_test.rb
+++ b/test/integration/v1/users_api_test.rb
@@ -181,7 +181,17 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "non-blessed clients can\"t delete a user" do
+  test "a 412 is returned when deleting a user that is an owner of a site" do
+    client_auth(:blessed_app)
+
+    user = users(:david)
+    assert_no_difference "User.count" do
+      delete "/users/#{user.id}"
+      assert_response :precondition_failed
+    end
+  end
+
+  test 'non-blessed clients can\'t delete a user' do
     client_auth
 
     user = create(:user)

--- a/test/integration/v1/users_api_test.rb
+++ b/test/integration/v1/users_api_test.rb
@@ -113,12 +113,12 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
 
     assert_no_difference "User.count" do
       post "/users", user_params(email: user.email)
-      assert_response 422
+      assert_response :unprocessable_entity
     end
 
     assert_no_difference "User.count" do
       post "/users", user_params(password: "")
-      assert_response 422
+      assert_response :unprocessable_entity
     end
   end
 

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class SiteTest < ActiveSupport::TestCase
+
+  test "name is required" do
+    site = Site.new(description: 'some description')
+
+    refute site.valid?
+    assert_equal 1, site.errors.size
+    assert site.errors.has_key?(:name)
+  end
+
+  test "name must be unique" do
+    site = sites(:pseudocms)
+    new_site = Site.new(name: site.name, description: 'some description')
+
+    refute new_site.save
+    assert_equal 1, new_site.errors.size
+    assert new_site.errors.has_key?(:name)
+  end
+end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -18,4 +18,13 @@ class SiteTest < ActiveSupport::TestCase
     assert_equal 1, new_site.errors.size
     assert new_site.errors.has_key?(:name)
   end
+
+  test "creating a site, creates the association with the owner" do
+    new_site = Site.new(name: 'some site', owner: users(:david))
+    new_site.run_callbacks(:commit) do
+      new_site.save!
+    end
+
+    assert_equal 1, new_site.users.size
+  end
 end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -11,8 +11,9 @@ class SiteTest < ActiveSupport::TestCase
   end
 
   test "name must be unique" do
-    site = sites(:pseudocms)
-    new_site = Site.new(name: site.name, description: 'some description')
+    user = create(:user)
+    site = create(:site, owner: user)
+    new_site = Site.new(name: site.name, description: 'some description', owner: user)
 
     refute new_site.save
     assert_equal 1, new_site.errors.size
@@ -20,7 +21,7 @@ class SiteTest < ActiveSupport::TestCase
   end
 
   test "creating a site, creates the association with the owner" do
-    new_site = Site.new(name: 'some site', owner: users(:david))
+    new_site = Site.new(name: 'some site', owner: create(:user))
     new_site.run_callbacks(:commit) do
       new_site.save!
     end


### PR DESCRIPTION
Simple CRUD endpoints for managing sites.
# The Model

Each site defines a site owner (`User`) that owns the site. Currently, the only special permission the owner has is the ability to delete the site. This will probably change over time...

There is also a many-to-many relationship between `Site` and `User` (via `has_and_belongs_to_many`) so that users can be "associated" with many sites, allowing them to update and view site details.
# Endpoints

| endpoint | verb | description | required_permission |
| --- | --- | --- | --- |
| `/sites` | `GET` | Gets a paginated list of sites. All sites if `blessed_app?`, otherwise sites the current user is associates with | user or blessed app |
| `/sites` | `POST` | Creates a new site with current user as the owner. If `blessed_app?`, uses a pseudo-parameter on site called `owner_id` (stripped unless blessed_app) | user or blessed app |
| `/sites/:id` | `GET` | Gets the site by id. Unless `blessed_app?` the user must be associated with the specified site | user or blessed app |
| `/sites/:id` | `PATCH` | Updates a site. Unless `blessed_app?` the user must be associated with the specified site | user or blessed app |
| `/sites/:id` | `DELETE` | Deletes the specified site. Unless `blessed_app?` the user must be the site owner to destroy a site. | owner or blessed app |
