### PR TITLE
Standardizing API Responses for Update and Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,58 @@
 This can be found in the response header `X-Request-Id`. It will be a unique value in the
 `8-4-4-4-12` format.
 
+### Status Codes
+
+Standard HTTP status codes are used throughout this API.
+
+#### POST Requests
+
+POST requests, when successful, will return `HTTP 201` and include the location (URI) for the newly
+created resource in the `Location` header.
+
+In some cases where some condition for creating is not satisfied, a `HTTP 412` will be used.
+
+#### PUT/PATCH Requests
+
+PATCH requests will return `HTTP 204` and per the spec, not include a body in the response.
+
+In some cases where some condition for updating is not satisfied, a `HTTP 412` will be used.
+
+#### DELETE Requests
+
+DELETE requests will return `HTTP 204` and per the spec, not include a body in the response.
+
+#### Error States
+
+Errors will always return a message body with a status and description of the error. The response
+will look similar to this:
+
+```javascript
+{
+  "errors": {
+    "message": "Permission denied",
+    "status": 403
+  }
+}
+```
+
+Standard errors include:
+
+* `Unauthenticated`: Missing the authentication header - `HTTP 401`
+* `Unauthorized`: Bad credentials/auth token - `HTTP 403`
+* `Resource not found`: Resource (or subresource) not found - `HTTP 404`
+
+There is one special case for error checking. When validation fails during a `POST/PUT/PATCH` call,
+a `HTTP 422` is returned with the errors containing the validations that failed. For example:
+
+```javascript
+{
+  "errors": {
+    "field_name": ["error message 1", "error message 2"]
+  }
+}
+```
+
 ### Always Use Standard UTC Timestamps
 
 This API accepts and returns times in UTC format only. Rendered times will be in ISO8601 format. For

--- a/test/integration/v1/sites_api_test.rb
+++ b/test/integration/v1/sites_api_test.rb
@@ -160,7 +160,7 @@ class V1::SitesAPITest < ActionDispatch::IntegrationTest
     site = make_site(user)
 
     patch "/sites/#{site.id}", site_params(name: "silly_site", description: "desc")
-    assert_response :success
+    assert_successful_update
 
     site.reload
     assert_equal "silly_site", site.name
@@ -172,7 +172,7 @@ class V1::SitesAPITest < ActionDispatch::IntegrationTest
     site = make_site(user, users: [user, other_user])
 
     patch "/sites/#{site.id}", site_params(name: "updated_site")
-    assert_response :success
+    assert_successful_update
   end
 
   test "a user that is not associated with a site cannot update it" do
@@ -190,7 +190,7 @@ class V1::SitesAPITest < ActionDispatch::IntegrationTest
     site = make_site(user)
 
     patch "/sites/#{site.id}", site_params(name: "New Name")
-    assert_response :success
+    assert_successful_update
   end
 
   test "updating a site fails with invalid parameters" do
@@ -221,6 +221,7 @@ class V1::SitesAPITest < ActionDispatch::IntegrationTest
 
     assert_difference "Site.count", -1 do
       delete "/sites/#{site.id}"
+      assert_successful_delete
     end
   end
 
@@ -242,7 +243,7 @@ class V1::SitesAPITest < ActionDispatch::IntegrationTest
 
     assert_difference "Site.count", -1 do
       delete "/sites/#{site.id}"
-      assert_response :no_content
+      assert_successful_delete
     end
   end
 

--- a/test/integration/v1/users_api_test.rb
+++ b/test/integration/v1/users_api_test.rb
@@ -28,14 +28,6 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     assert api_response.size > 0
   end
 
-  test "getting all users sets the link header" do
-    client_auth(blessed: true)
-
-    get "/users"
-    assert_response :ok
-    assert response.headers.has_key?("Link")
-  end
-
   test "GET /user returns the currently logged in user" do
     user_auth(:david)
 
@@ -126,7 +118,7 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     user = user_auth(:david)
 
     patch "/users/#{user.id}", user_params
-    assert_response :success
+    assert_successful_update
     assert_equal user_params[:email], user.reload.email
   end
 
@@ -150,7 +142,7 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
 
     user = create(:user, email: "david@pseudocms.com")
     patch "/users/#{user.id}", user_params
-    assert_response :success
+    assert_successful_update
     assert_equal user_params[:email], user.reload.email
   end
 
@@ -168,7 +160,7 @@ class V1::UserAPITest < ActionDispatch::IntegrationTest
     user = create(:user)
     assert_difference "User.count", -1 do
       delete "/users/#{user.id}"
-      assert_response :no_content
+      assert_successful_delete
     end
   end
 

--- a/test/support/core_ext/action_dispatch/integration_test.rb
+++ b/test/support/core_ext/action_dispatch/integration_test.rb
@@ -5,6 +5,12 @@ class ActionDispatch::IntegrationTest
   include APITest
   include PaginationTest
 
+  def assert_successful_update
+    assert_response :no_content
+    assert response.body.blank?
+  end
+  alias_method :assert_successful_delete, :assert_successful_update
+
   def assert_permission_denied
     assert_error(:forbidden, message: "Permission denied")
   end
@@ -24,11 +30,11 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  private
-
   def api_response
     @api_response ||= JSON.parse(response.body)
   end
+
+  private
 
   def model_under_test
     @modal_under_test ||= begin


### PR DESCRIPTION
Ensuring HTTP 204 is returned with no response body (as defined by the spec).
